### PR TITLE
Site menu no semantic ui

### DIFF
--- a/src/site/_includes/css/navmenu.css
+++ b/src/site/_includes/css/navmenu.css
@@ -11,7 +11,8 @@
     background-color: #FFFFFF;
 }
 
-#navigation-menu {
+#navigation-menu,
+#newNavigation-menu {
     position: absolute;
     left: 1200px;
     top: 10px;
@@ -19,11 +20,8 @@
 }
 
 #newNavigation-menu {
-    position: absolute;
     /* left: 1200px; */
     left: 1080px;
-    top: 10px;
-    font-family: 'Open Sans ExtraBold', sans-serif;
 }
 
 #navigation-menu .menu {
@@ -59,26 +57,67 @@
 
 /* newNavigation-menu substyles */
 
-#newNavigation-menu .menu {
-    left: auto;
-    right: 0px;
+#menu-toggle {
+    padding: 0;
+    background: transparent;
+    border: none;
+}
+
+/* effect to let user know this is interact-able */
+#menu-toggle:hover {
+    /* temporary.. if using this, need a scalable (larger initial) image,
+    or svg, so it isn't blurry */
+    transform: scale(1.1); 
+}
+
+.site-nav {
+    position: absolute;
+        right: 0px;
     background-color: #2E2C3D;
     border: 1px solid #FFFFFF;
+    border-radius: .28571429rem;
+    box-shadow: 0 2px 3px 0 rgba(34,36,38,.15);
+    transform-origin: top;
+    -webkit-transition: opacity .2s ease, transform .3s ease;
+    transition: opacity .2s ease, transform .3s ease;
 }
 
-#newNavigation-menu .menu > .item {
-    padding: 0px !important;
+#newNavigation-menu[data-state="closed"] .site-nav {
+    transform: scaleY(0);
+    opacity: 0;
 }
 
-#newNavigation-menu a:hover {
-    border-radius: 5px;
-    background-color: #443D66;
+#newNavigation-menu[data-state="open"] .site-nav {
+    transform: scaleY(1);
+    opacity: 100;
 }
 
-#newNavigation-menu a {
+.nav-list {
+    margin: 0;
+    padding: 0;
+    min-width: max-content;
+    list-style: none;
+}
+
+.nav-item {
+    line-height: 1em;
+    font-size: 1rem;
+}
+
+.site-nav a {
     padding: 14px;
     display: block;
     width: 100%;
     height: 100%;
     color: #FFFFFF;
+}
+
+.site-nav a:hover {
+    border-radius: 5px;
+    background-color: #443D66;
+}
+
+.nav-item.child a::before {
+    content: '\2022';
+    margin-right: .8em;
 }

--- a/src/site/_includes/css/navmenu.css
+++ b/src/site/_includes/css/navmenu.css
@@ -73,6 +73,7 @@
 .site-nav {
     position: absolute;
         right: 0px;
+        z-index: 11;
     background-color: #2E2C3D;
     border: 1px solid #FFFFFF;
     border-radius: .28571429rem;

--- a/src/site/_includes/js/header.js
+++ b/src/site/_includes/js/header.js
@@ -1,0 +1,13 @@
+
+// Header JS
+  // toggle menu
+  // initial "header.dataset.state == 'closed'"
+  const navMenu = document.getElementById('newNavigation-menu');
+  toggleMenu = () => {
+    if (navMenu.dataset.state === "closed") {
+        navMenu.dataset.state = "open";
+    }
+    else {
+        navMenu.dataset.state = "closed";
+    }
+  }

--- a/src/site/_includes/partials/html-head/styles.njk
+++ b/src/site/_includes/partials/html-head/styles.njk
@@ -1,6 +1,6 @@
   <!-- CSS -->
   <link href="{{ "/styles/site.css" | url }}" rel="stylesheet" type="text/css">
-  <link href="{{ "/epc/epc.css" | url }}" rel="stylesheet" type="text/css">
+  {# <link href="{{ "/epc/epc.css" | url }}" rel="stylesheet" type="text/css"> #}
   {%- if legacy %}
   <link href="/styles/{{ legacy }}" rel="stylesheet" type="text/css">
   {%- endif %}

--- a/src/site/_includes/partials/html-head/styles.njk
+++ b/src/site/_includes/partials/html-head/styles.njk
@@ -4,6 +4,12 @@
   {%- if legacy %}
   <link href="/styles/{{ legacy }}" rel="stylesheet" type="text/css">
   {%- endif %}
+    {#- if `page_styles` data is passed, include those CSS files here -#}
+  {%- if page_styles %}
+    {%- for style in page_styles %}
+  <link href="{{ style | url }}" rel="stylesheet" type="text/css">
+    {%- endfor %}
+  {%- endif %}
 
     {#- if `page_style` data is passed, include that CSS partial here -#}
   {%- if page_style %}

--- a/src/site/_includes/partials/navigation/navMenu.njk
+++ b/src/site/_includes/partials/navigation/navMenu.njk
@@ -1,47 +1,26 @@
 {# Dropdown menu for navigation #}
 {# &RelativeURL #}
 
-      <div class="ui dropdown" id="newNavigation-menu" tabindex="0">
+      <div id="newNavigation-menu" data-state="closed">
 
-        <img src="https://www.shiftstoned.com/global/images/navigation-menu.png" />
+        <button type="button"
+                id="menu-toggle"
+                onclick="toggleMenu()">
+          <img src="https://www.shiftstoned.com/global/images/navigation-menu.png" />
+          <span class="visually-hidden hidden-focusable">toggle header menu</span>
+        </button>
 
-        <div class="menu left transition hidden" tabindex="-1">
-
-          <div class="item">
-            <a href="/">HOME </a>
-          </div>
-
-          <div class="item">
-            <a href="/epc/">POWER CALCULATOR </a>
-          </div>
-
-          <div class="item">
-            <div class="navigation-menu-indent">
-              <a href="/epc/about/">&bull;</a>
-            </div>
-            <a href="/epc/about/">Guide</a>
-          </div>
-
-          <div class="item">
-            <a href="/calendar/">COMMUNITY CALENDAR</a>
-          </div>
-
-          <div class="item">
-            <a href="/drafter/">DRAFTER</a>
-          </div>
-
-          <div class="item">
-            <a href="/players/">PLAYERS</a>
-          </div>
-
-          <div class="item">
-            <a href="/articles/">ARTICLES</a>
-          </div>
-
-          <div class="item">
-            <a href="/contact">CONTACT</a>
-          </div>
-
-        </div>
+        <nav class="site-nav">
+          <ul class="nav-list">
+            <li class="nav-item"><a href="/">HOME</a></li>
+            <li class="nav-item"><a href="/epc/">POWER CALCULATOR </a></li>
+            <li class="nav-item child"><a href="/epc/about/">Guide</a></li>
+            <li class="nav-item"><a href="/calendar/">COMMUNITY CALENDAR</a></li>
+            <li class="nav-item"><a href="/drafter/">DRAFTER</a></li>
+            <li class="nav-item"><a href="/players/">PLAYERS</a></li>
+            <li class="nav-item"><a href="/articles/">ARTICLES</a></li>
+            <li class="nav-item"><a href="/contact">CONTACT</a></li>
+          </ul>
+        </nav>
 
       </div>

--- a/src/site/_includes/partials/scripts/jsSrc.njk
+++ b/src/site/_includes/partials/scripts/jsSrc.njk
@@ -5,3 +5,17 @@
     <script type="text/javascript">$(".ui.dropdown").dropdown();</script> #}
     <!-- defer loading non-critical js -->
     <script defer src="/scripts/site-defer.js" type="text/javascript"></script>
+    
+    {#- if page-specific `page_script` data is passed, include that js file here -#}
+  {%- if page_script %}
+    <!-- page-specific js -->
+    <script src="{{ page_script | url }}" type="text/javascript"></script>
+  {%- endif %}
+    
+    {#- if multiple page-specific `page_scripts` data is passed, include those js files here -#}
+  {%- if page_scripts %}
+    <!-- page-specific js -->
+    {%- for script in page_scripts %}
+    <script src="{{ script | url }}" type="text/javascript"></script>
+    {%- endfor %}
+  {%- endif %}

--- a/src/site/_includes/partials/scripts/jsSrc.njk
+++ b/src/site/_includes/partials/scripts/jsSrc.njk
@@ -1,5 +1,7 @@
 {#- Consolidating the various scripts into a single include -#}
-    <script type="text/javascript" src="/epc/jquery-1.12.4.min.js"></script>
+    {# <script type="text/javascript" src="/epc/jquery-1.12.4.min.js"></script>
     <script type="text/javascript" src="/epc/semantic.min.js"></script>
     <script type="text/javascript" src="/epc/epc.min.js"></script>
-    <script type="text/javascript">$(".ui.dropdown").dropdown();</script>
+    <script type="text/javascript">$(".ui.dropdown").dropdown();</script> #}
+    <!-- defer loading non-critical js -->
+    <script defer src="/scripts/site-defer.js" type="text/javascript"></script>

--- a/src/site/epc/index.njk
+++ b/src/site/epc/index.njk
@@ -4,6 +4,12 @@ bg_img: ../images/BackgroundEpc.jpg
 section: Epc
 about: about/
 title: Eternal Power Calculator
+page_styles:
+    - "/epc/epc.css"
+page_scripts:
+    - "/epc/jquery-1.12.4.min.js"
+    - "/epc/semantic.min.js"
+    - "/epc/epc.min.js"
 ---
 
 {% include "partials/epc/epccore.njk" %}

--- a/src/site/scripts/site-defer_js.njk
+++ b/src/site/scripts/site-defer_js.njk
@@ -4,7 +4,7 @@ permalink: scripts/site-defer.js
 {# capture the JAVASCRIPT content as a Nunjucks variable -#}
 {%- set js -%}
 {# {% include "js/base.js" %} #}
-{# {% include "js/header.js" %} #}
+{% include "js/header.js" %}
 {%- endset -%}
 {#- output-#}
 {{- js | safe -}}


### PR DESCRIPTION
- Stripped `semantic.ui` from site drop-down menu, now only uses native css + small javascript function for toggling the menu's open/closed state
- Removed `semantic.ui` & other EPC-specific js/css from loading on all site pages
- Re-added EPC js/css to only the EPC tool page itself, using new frontmatter options to load 1 or more output js/css files

Note that the new frontmatter options overlap somewhat with existing options' naming and functionality. some clean-up/merging may be needed.
