### PR TITLE
drafter pages background now relative to site root

### DIFF
--- a/src/site/drafter/drafter.json
+++ b/src/site/drafter/drafter.json
@@ -1,7 +1,7 @@
 {
     "layout" : "layouts/html.njk",
     "section" : "Drafter",
-    "bg_img" : "../images/BackgroundDrafter.jpg",
+    "bg_img" : "/images/BackgroundDrafter.jpg",
     "tags" : "drafter",
     "templateEngineOverride": "njk,md"
   }


### PR DESCRIPTION
The background image url path for `/drafter` & subpages is now relative to the root (`/images/file.jpg`), rather than the current page (`../images/file.jpg`).